### PR TITLE
add rigor rubrics and unittests

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ from yescieval.rubric.pointwise.innovation import StateOfTheArtAndNovelty
 from yescieval.rubric.pairwise.depth import MechanisticUnderstanding, CausalReasoning, TemporalPrecision
 # Breadth rubrics
 from yescieval.rubric.pairwise.breadth import ContextCoverage, MethodCoverage, DimensionCoverage, ScaleCoverage, ScopeCoverage
+# Rigor rubrics
+from yescieval.rubric.pairiwise.rigor import EpistemicCalibration, QuantitativeEvidenceAndUncertainty, ExplicitUncertainty
 ```
 
 A complete list of rubrics are available at YESciEval [📚 Rubrics](https://yescieval.readthedocs.io/rubrics.html) page.

--- a/docs/source/rubrics.rst
+++ b/docs/source/rubrics.rst
@@ -43,6 +43,8 @@ Each rubric can be used in two ways:
         from yescieval.rubric.pairwise.depth import MechanisticUnderstanding, CausalReasoning, TemporalPrecision
         # Pairwise breadth rubrics
         from yescieval.rubric.pairwise.breadth import ContextCoverage, MethodCoverage, DimensionCoverage, ScaleCoverage, ScopeCoverage
+        # Pairwise rigor rubrics
+        from yescieval.rubric.pairwise.rigor import EpistemicCalibration, QuantitativeEvidenceAndUncertainty, ExplicitUncertainty
 
 
 Pairwise Evaluation
@@ -365,13 +367,25 @@ Assesses the evidentiary and methodological integrity of the synthesis.
        like "unknown," "limited evidence," or "unclear"?
 
 
-.. tab:: Basic usage
+.. tab:: Pointwise usage
 
   .. code-block:: python
 
      from yescieval.rubric.pointwise.rigor import EpistemicCalibration
 
      rubric      = EpistemicCalibration(papers=papers, question=question, answer=answer)
+     instruction = rubric.instruct()
+
+     print(instruction)
+     print(rubric.name)
+
+.. tab:: Pairwise Usage
+
+  .. code-block:: python
+
+     from yescieval.rubric.pairwise.rigor import EpistemicCalibration
+
+     rubric      = EpistemicCalibration(papers=papers, question=question, answer_a=answer_a, answer_b=answer_b)
      instruction = rubric.instruct()
 
      print(instruction)

--- a/test/test_rubrics.py
+++ b/test/test_rubrics.py
@@ -1,4 +1,5 @@
 import unittest
+from yescieval import ExampleInjector, VocabularyInjector
 from yescieval.rubric.pointwise.fidelity import Informativeness
 from yescieval.rubric.pointwise.depth import CausalReasoning
 from yescieval.rubric.pairwise.breadth import MethodCoverage
@@ -60,6 +61,58 @@ class TestPairwiseRubric(unittest.TestCase):
             question=self.question,
             answer_a=self.answer_a,
             answer_b=self.answer_b,
+        )
+        output = rubric.instruct()
+        self.assertIsInstance(output, list)
+        self.assertTrue(len(output) > 0)
+        
+class TestInjectors(unittest.TestCase):
+ 
+    def setUp(self):
+        self.papers = {
+            "A Study on AI": "This paper discusses recent advances in artificial intelligence, including deep learning.",
+            "Machine Learning Basics": "An overview of supervised learning methods such as decision trees and SVMs.",
+            "Neural Networks Explained": "Explains backpropagation and gradient descent for training networks.",
+        }
+        self.question = "this is a dummy question"
+        self.answer_a = "synthesis answer A"
+        self.answer_b = "synthesis answer B"
+ 
+    def test_vocabulary_injector(self):
+        rubric = MethodCoverage(
+            papers=self.papers,
+            question=self.question,
+            answer_a=self.answer_a,
+            answer_b=self.answer_b,
+            domain="ecology",
+            vocabulary=VocabularyInjector(),
+        )
+        output = rubric.instruct()
+        self.assertIsInstance(output, list)
+        self.assertTrue(len(output) > 0)
+ 
+    def test_example_injector(self):
+        rubric = MethodCoverage(
+            papers=self.papers,
+            question=self.question,
+            answer_a=self.answer_a,
+            answer_b=self.answer_b,
+            domain="ecology",
+            example=ExampleInjector(),
+        )
+        output = rubric.instruct()
+        self.assertIsInstance(output, list)
+        self.assertTrue(len(output) > 0)
+ 
+    def test_both_injectors(self):
+        rubric = MethodCoverage(
+            papers=self.papers,
+            question=self.question,
+            answer_a=self.answer_a,
+            answer_b=self.answer_b,
+            domain="ecology",
+            vocabulary=VocabularyInjector(),
+            example=ExampleInjector(),
         )
         output = rubric.instruct()
         self.assertIsInstance(output, list)

--- a/yescieval/injector/domains/ecology.py
+++ b/yescieval/injector/domains/ecology.py
@@ -238,7 +238,7 @@ example_responses = {
                 }
             ] 
         }
-        },
+},
     "pairwise": {
         "Depth": {
             "MechanisticUnderstanding": {
@@ -419,7 +419,75 @@ example_responses = {
                     }
                 ]
             }
-}    
+        },
+        "Rigor": {
+            "EpistemicCalibration": {
+                "ResponseA": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response makes strong, unqualified claims about ecological findings or implications without acknowledging any uncertainty, limitations, assumptions, or alternative explanations. No hedging language is used, and the response presents contested or context-dependent ecological conclusions as established fact."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response demonstrates good epistemic calibration by acknowledging uncertainty, limitations, assumptions, and alternative explanations relevant to the ecological findings or implications. It uses appropriately qualified language (e.g., 'evidence suggests,' 'under these conditions,' 'one possible explanation') when discussing population dynamics, species interactions, or environmental impacts, though minor gaps or occasional vague hedging may remain."
+                    }
+                ],
+                "ResponseB": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response presents ecological claims with unwarranted confidence, asserting definitive cause-effect relationships between species populations and environmental factors without acknowledging data limitations, methodological assumptions, or competing explanations, giving the impression that findings are more settled than they are."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response is well-calibrated, consistently qualifying ecological claims with appropriate uncertainty (e.g., 'current evidence indicates,' 'this may vary by context,' 'alternative mechanisms could include') and acknowledging the limitations of cited studies or models. Cross-scale and context-dependent nuances are noted where relevant, with only minor instances of vague or missing hedging."
+                    }
+                ]
+            },
+            "QuantitativeEvidenceAndUncertainty": {
+                "ResponseA": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response summarizes ecological patterns in purely qualitative terms (e.g., 'species declined' or 'abundance increased') without providing or interpreting any quantitative measures such as population change rates, effect sizes, or variability estimates. No uncertainty, sampling limitations, or heterogeneity across sites or time periods is addressed, leaving the ecological claims unsubstantiated and imprecise."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response uses relevant quantitative evidence (e.g., percentage changes in population abundance, reported confidence intervals, or effect sizes across sites) and links these figures to the research question. It discusses uncertainty and limitations such as short time series, site-specific variability, or mixed results across studies, and avoids overgeneralization, with only minor gaps in robustness or comparability discussion."
+                    }
+                ],
+                "ResponseB": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response describes ecological findings using only vague directional language (e.g., 'populations were lower' or 'diversity improved') without citing any quantitative data, statistical measures, or confidence ranges. Sampling limitations, measurement uncertainty, and cross-site heterogeneity are entirely absent, making it impossible to assess the strength or reliability of the ecological claims."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response integrates quantitative evidence effectively (e.g., referencing reported rates of habitat loss, species richness indices, or variation across study sites) and connects these to the broader ecological question. Uncertainty is explicitly acknowledged through discussion of data limitations such as short monitoring periods, uneven sampling effort, or inconsistent results across regions, and conclusions are appropriately hedged to avoid overgeneralization, with only minor omissions in comparability or robustness."
+                    }
+                ]
+            },
+            "ExplicitUncertainty": {
+                "ResponseA": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response does not explicitly acknowledge any uncertainty, limitations, or assumptions related to the ecological findings or implications. For example, it presents conclusions about species population trends or habitat dynamics as fully settled without noting data gaps, confounding environmental variables, or the site-specific nature of the findings."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response explicitly acknowledges uncertainty, limitations, and assumptions related to the ecological findings or implications, using clear language to identify areas of ambiguity, unresolved questions, or potential confounding factors (e.g., noting that observed population declines may reflect sampling artifacts, that results are contingent on local climate conditions, or that long-term trends remain unclear due to short monitoring periods)."
+                    }
+                ],
+                "ResponseB": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response presents ecological claims and implications without explicitly identifying any limitations, assumptions, or areas of uncertainty. Findings related to ecosystem dynamics, species interactions, or environmental impacts are stated as definitive conclusions, with no mention of confounding factors, measurement limitations, or unresolved ecological questions."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response clearly and explicitly flags uncertainty, limitations, and assumptions throughout, using direct language to identify ambiguous or unresolved aspects of the ecological findings (e.g., acknowledging that causal mechanisms between disturbance regimes and biodiversity loss remain debated, that extrapolation across biomes may not be valid, or that study designs preclude ruling out alternative explanations). Potential confounding factors are named and their implications for interpreting results are discussed."
+                    }
+                ]
+            }
+        }    
     }
 }
 

--- a/yescieval/injector/domains/nlp.py
+++ b/yescieval/injector/domains/nlp.py
@@ -244,7 +244,7 @@ example_responses = {
                 }  
             ]   
         }
- },
+    },
     "pairwise": { 
         "Depth": {
             "MechanisticUnderstanding": {
@@ -425,9 +425,76 @@ example_responses = {
                     }
                 ]
             }
-}        
-        
-        }
+        }, 
+        "Rigor": {
+            "EpistemicCalibration": {
+                "ResponseA": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response presents claims as definitive throughout, with no meaningful qualification, uncertainty marking, or acknowledgment of assumptions or limitations. For example, it asserts that a model architecture universally outperforms others or that benchmark results directly reflect real-world performance, without noting dataset-specific conditions, evaluation constraints, or reproducibility concerns."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response generally calibrates claim strength well, distinguishing supported results from uncertain ones (e.g., noting that performance improvements hold on standard English benchmarks but that generalization to low-resource or multilingual settings remains unclear due to limited evaluation). Appropriate hedging language is used throughout, with only minor instances of vague qualification."
+                    }
+                ],
+                "ResponseB": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response makes sweeping, unqualified assertions about model capabilities or findings (e.g., claiming a fine-tuned model definitively solves a task or that a particular training approach always leads to better generalization) without acknowledging data limitations, architectural assumptions, benchmark constraints, or alternative interpretations of results."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response is well-calibrated, consistently qualifying claims with appropriate uncertainty (e.g., 'results suggest,' 'under these evaluation conditions,' 'performance may degrade on out-of-domain data') and acknowledging the limitations of cited benchmarks, training data, or model assumptions. Distinctions between in-distribution and out-of-distribution performance are noted where relevant, with only minor gaps in hedging."
+                    }
+                ]
+            },
+            "QuantitativeEvidenceAndUncertainty": {
+                "ResponseA": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response does not provide any quantitative evidence or statistical analysis to support its claims (e.g., asserting that one model outperforms another without citing accuracy, F1 scores, or other metrics), and does not acknowledge uncertainty, variance across datasets, or limitations in the evaluation setup."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response appropriately uses quantitative results (e.g., reporting F1 score improvements over baselines and noting variance across datasets) and connects them to the research question. It acknowledges uncertainty and limitations such as performance drops on out-of-domain data or results being based on a limited set of benchmarks, with only minor gaps in cross-study comparison or robustness analysis."
+                    }
+                ],
+                "ResponseB": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response describes model performance using only vague qualitative language (e.g., 'the model performed better' or 'results improved significantly') without citing any quantitative metrics, confidence intervals, or statistical significance measures. Variability across tasks, datasets, or evaluation conditions is entirely absent, making it impossible to assess the reliability or generalizability of the reported findings."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response effectively integrates quantitative evidence (e.g., referencing BLEU score gains, precision-recall tradeoffs, or performance variance across benchmark datasets) and links these figures to the broader research question. Uncertainty is explicitly addressed through discussion of limitations such as restricted benchmark coverage, sensitivity to hyperparameter choices, or inconsistent results across languages or domains, and conclusions are appropriately hedged to avoid overgeneralization, with only minor omissions in robustness or cross-study comparability."
+                    }
+                ]
+            },
+            "ExplicitUncertainty": {
+                "ResponseA": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response does not explicitly acknowledge any uncertainty, unknowns, or open questions related to the research question. For example, it presents model performance results or architectural design choices as definitive and well-established without noting evaluation limitations, unresolved questions about generalization, or areas where the evidence remains inconclusive."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response explicitly acknowledges uncertainty, unknowns, and open questions related to the research question, using clear language to indicate what is not yet known or understood (e.g., noting that it remains unclear whether performance gains on English benchmarks transfer to low-resource languages, or that the mechanisms behind emergent model behaviors are not well understood). Areas where evidence is limited or inconclusive are highlighted, with only minor gaps in explicit acknowledgment of uncertainty."
+                    }
+                ],
+                "ResponseB": [
+                    {
+                        "rating": "1",
+                        "rationale": "The response presents findings and conclusions as fully settled and definitive, with no explicit acknowledgment of uncertainty, open questions, or limitations in the current evidence. Claims about model capabilities, training procedures, or benchmark results are stated without flagging unresolved debates, dataset biases, or gaps in the literature that would warrant caution."
+                    },
+                    {
+                        "rating": "4",
+                        "rationale": "The response clearly and explicitly flags uncertainty and open questions throughout, using direct language to identify what remains unresolved or poorly understood in the context (e.g., acknowledging that the robustness of fine-tuning approaches across diverse domains is still an open question, that evaluation on limited benchmarks leaves generalizability uncertain, or that conflicting results across studies have not yet been reconciled). Areas of limited or inconclusive evidence are named and their implications for interpreting the findings are discussed, with only minor gaps in explicit uncertainty acknowledgment."
+                    }
+                ]
+            }
+        }           
+    }
 }
 
 

--- a/yescieval/injector/example.py
+++ b/yescieval/injector/example.py
@@ -12,7 +12,7 @@ class ExampleInjector(ABC):
     examples_placeholder = "{EXAMPLE_RESPONSES}"
     empty_placeholder = "{}"
 
-    def format_example(self, domain: str, rubric_id: str, eval_type: str = "pointwise") -> Any:
+    def format_example(self, domain: str, rubric_id: str, eval_type: str) -> Any:
         """
         Returns:
             {rubric_id: <example_object>} if found,
@@ -22,7 +22,7 @@ class ExampleInjector(ABC):
         domain_data = example_responses.get(domain_id, {})
         if not domain_data:
             return None
-        eval_data = domain_data.get(eval_type, {}) # pointwise or pairwise
+        eval_data = domain_data.get(eval_type, {}) 
         if not eval_data:
             return None
         for _, rubrics in eval_data.items():
@@ -31,7 +31,7 @@ class ExampleInjector(ABC):
         return None
 
 
-    def format_prompt(self, prompt: str, domain: str, rubric_id: str, eval_type: str = "pointwise") -> str:
+    def format_prompt(self, prompt: str, domain: str, rubric_id: str, eval_type: str) -> str:
         """
         Injects example responses JSON into the template.
         """

--- a/yescieval/rubric/pairwise/rigor/__init__.py
+++ b/yescieval/rubric/pairwise/rigor/__init__.py
@@ -1,0 +1,5 @@
+from .epistemic_calibration import EpistemicCalibration
+from .explicit_uncertainty import ExplicitUncertainty
+from .quantitative_evidence import QuantitativeEvidenceAndUncertainty
+
+__all__ = [ "EpistemicCalibration", "ExplicitUncertainty", "QuantitativeEvidenceAndUncertainty"]

--- a/yescieval/rubric/pairwise/rigor/epistemic_calibration.py
+++ b/yescieval/rubric/pairwise/rigor/epistemic_calibration.py
@@ -1,0 +1,83 @@
+from ....base import PairwiseRubric
+
+epistemic_calibration_pairwise_prompt = """<Context>
+Scientific question answering and synthesis often require more than listing findings: high-quality scientific writing is epistemically calibrated. It distinguishes what is well-supported by evidence from what is uncertain, inferred, assumed, or hypothetical. In synthesis settings, this includes clearly marking speculative or low-confidence claims and appropriately qualifying conclusions when evidence is limited, mixed, indirect, or not comparable.
+
+Importantly, Uncertainty marking should be specific and meaningful—not generic hedging. Strong calibration flags, which claim is uncertain and, when possible, why (e.g., limited data, conflicting results, methodological constraints, extrapolation beyond the studied setting). Overuse of vague hedges (“might/could”) without a clear scope does not indicate high rigor.
+
+The responses may be short paragraphs or long-form reports. Epistemic calibration should be evaluated independently of presentation style or length.
+
+This rubric focuses exclusively on the presence and quality of epistemic calibration within the provided text of two responses that are compared, whether uncertainty, assumptions, or hypotheses are explicitly and appropriately marked, and whether the strength of language matches the strength of support. Other aspects of scientific quality (such as factual accuracy, mechanistic understanding, evidential grounding, or completeness) are intentionally outside its scope and are assessed by separate evaluation criteria.
+</Context>
+
+<Role>
+You are tasked as a scientific writing quality evaluator performing a pairwise comparison between two texts.
+</Role>
+
+<Task-Description>
+A user will provide:
+1) a research question, and
+2) Two written responses (Response A and Response B) intended to address that question.
+
+Your task is to:
+- First, independently evaluate each response using the evaluation characteristic below.
+- Then perform a pairwise comparison of the two responses using the evaluation characteristic below.
+- Then grade each response with a comparative rating from 1 (very bad) to 5 (very good) compared to the other response and a subsequent rationale for each comparative response rating.
+- Note that it is possible for both responses to receive the same rating, if they are equally comparably clear with meaningful epistemic calibration and provide complementary or identical insights.
+
+Your judgment must be based solely on the provided question and comparing the two responses w.r.t. addressing the question and w.r.t. each other.
+</Task-Description>
+
+<Evaluation-Characteristic>
+EpistemicCalibration: Does the response appropriately calibrate claim strength by clearly distinguishing well-supported claims from uncertain, inferred, assumed, or hypothetical content, and by explicitly and meaningfully marking uncertainty/limitations where relevant to the research question?
+</Evaluation-Characteristic>
+
+<Domain-Vocabulary-Examples>
+Below are terms and phrases that often signal epistemic calibration. They are examples only: their presence is not required, and their presence alone is not sufficient for a high score.
+{EPISTEMIC_CALIBRATION_VOCAB}
+</Domain-Vocabulary-Examples>
+
+<Rating-Scale>
+For the characteristic above, rate the quality from 1 (very bad) to 5 (very good). Follow the guidelines specified below.
+
+EpistemicCalibration
+Rating 1. Very bad: The response presents claims as definitive throughout, with no meaningful qualification, uncertainty marking, or acknowledgment of assumptions/limitations, even when such caution is warranted.
+Rating 2. Bad: The response occasionally signals uncertainty or speculation, but markings are vague (generic “might/could”), inconsistently applied, or poorly scoped; claim strength often does not match the level of support.
+Rating 3. Moderate: The response includes some clearly marked uncertainty/assumptions/limitations relevant to the question, but calibration is uneven: important claims remain unqualified, or uncertainty is flagged without a clear scope or rationale.
+Rating 4. Good: The response is generally well-calibrated: it distinguishes supported claims from uncertain or hypothetical ones, uses appropriately qualified language, and marks key limitations or mixed evidence with reasonable specificity; minor gaps or occasional vague hedging may remain.
+Rating 5. Very good: The response demonstrates strong epistemic calibration throughout: it consistently aligns claim strength with support, explicitly marks uncertainty/assumptions/limitations with clear scope (what is uncertain and why), distinguishes inference/hypothesis from established findings, and avoids both overclaiming and empty hedging.
+</Rating-Scale>
+
+<Response-Format>
+Return your evaluation strictly in JSON format:
+
+{
+  "EpistemicCalibration": {
+    "ResponseA": {
+      "rating": "",
+      "rationale": ""
+    },
+    "ResponseB": {
+      "rating": "",
+      "rationale": ""
+    }
+  }
+}
+
+where:
+- "rating" is a number from 1 to 5.
+- "rationale" is the comparative evaluation rating justification.
+</Response-Format>
+
+<Example-Responses>
+{EXAMPLE_RESPONSES}
+</Example-Responses>
+
+<Note>
+Your evaluation must be based solely on the provided research question and responses. Do not reward verbosity or hedge words alone; reward meaningful, well-scoped calibration of claims, clear marking of uncertainty/assumptions/limitations, and appropriate alignment between language strength and support. This rubric does not assess factual correctness, evidential grounding, mechanistic understanding, or completeness.
+</Note>
+"""
+
+class EpistemicCalibration(PairwiseRubric):
+    name: str = "EpistemicCalibration"
+    system_prompt_template: str = epistemic_calibration_pairwise_prompt

--- a/yescieval/rubric/pairwise/rigor/explicit_uncertainty.py
+++ b/yescieval/rubric/pairwise/rigor/explicit_uncertainty.py
@@ -1,0 +1,81 @@
+from ....base import PairwiseRubric
+
+explicit_uncertainty_pairwise_prompt = """<Context>
+Scientific question answering and synthesis often require more than listing findings: high-quality scientific writing clearly communicates when conclusions or underlying knowledge remain uncertain, unclear, or unknown.
+
+The responses may be short paragraphs or long-form reports. Explicit uncertainty should be evaluated independently of presentation style or length.
+
+This rubric focuses exclusively on whether the provided text of two responses that are compared explicitly identifies knowledge as uncertain, unclear, or unknown in relation to the research question. Other aspects of scientific quality (such as factual completeness, causal reasoning, or relevancy) are intentionally outside its scope and are assessed by separate evaluation criteria.
+</Context>
+
+<Role>
+You are tasked as a scientific writing quality evaluator performing a pairwise comparison between two texts.
+</Role>
+
+<Task-Description>
+A user will provide:
+1) a research question, and
+2) Two written responses (Response A and Response B) intended to address that question.
+
+Your task is to:
+- First, independently evaluate each response using the evaluation characteristic below.
+- Then perform a pairwise comparison of the two responses using the evaluation characteristic below.
+- Then grade each response with a comparative rating from 1 (very bad) to 5 (very good) compared to the other response and a subsequent rationale for each comparative response rating.
+- Note that it is possible for both responses to receive the same rating if they are equally comparably clear with systematic uncertainties and provide complementary or identical insights.
+
+Your judgment must be based solely on the provided question and comparing the two responses w.r.t. addressing the question and w.r.t. each other.
+</Task-Description>
+
+<Evaluation-Characteristic>
+ExplicitUncertainty: Does the response clearly indicate what is uncertain, unclear, or unknown in relation to the research question, rather than presenting all findings as settled or certain?
+</Evaluation-Characteristic>
+
+<Domain-Vocabulary-Examples>
+Below are domain-specific terms and phrases that often signal explicit uncertainty discussion. These are examples only: their presence is not required, and their presence alone is not sufficient for a high score.
+{UNCERTAINTY_VOCAB}
+</Domain-Vocabulary-Examples>
+
+<Rating-Scale>
+For the characteristic above, rate the quality from 1 (very bad) to 5 (very good). Follow the guidelines specified below.
+
+Rating 1. Very bad: The response provides no indication of uncertainty; all statements are presented as settled, with no acknowledgment of what is uncertain, unclear, or unknown.
+Rating 2. Bad: The response occasionally signals uncertainty, but markers of what is uncertain, unclear, or unknown are vague, or weakly connected to the research question.
+Rating 3. Moderate: The response identifies some aspects that are uncertain, unclear, or unknown, but important elements are missing, inconsistently marked, or only partially explained.
+Rating 4. Good: The response clearly signals multiple uncertainties, unclear points, or unknown aspects relevant to the research question, minor gaps or imprecision in the explicit marking may remain.
+Rating 5. Very good: The response provides a detailed, coherent account of what is uncertain, unclear, or unknown, explicitly and consistently marking multiple aspects of unresolved knowledge and clearly distinguishing these from statements presented as certain or settled.
+</Rating-Scale>
+
+<Response-Format>
+Return your evaluation strictly in JSON format:
+
+{
+  "ExplicitUncertainty": {
+    "ResponseA": {
+      "rating": "",
+      "rationale": ""
+    },
+    "ResponseB": {
+      "rating": "",
+      "rationale": ""
+    }
+  }
+}
+
+where:
+- "rating" is a number from 1 to 5.
+- "rationale" is the comparative evaluation rating justification.
+
+</Response-Format>
+
+<Example-Responses>
+{EXAMPLE_RESPONSES}
+</Example-Responses>
+
+<Note>
+Your evaluation must be based solely on the provided research question and responses. Do not reward length by itself; reward clear and relevant identification of what is uncertain, unclear, or unknown. This rubric does not assess factual completeness, causal reasoning, or relevancy.
+</Note>
+"""
+
+class ExplicitUncertainty(PairwiseRubric):
+    name: str = "Explicit Uncertainty"
+    system_prompt_template: str = explicit_uncertainty_pairwise_prompt

--- a/yescieval/rubric/pairwise/rigor/explicit_uncertainty.py
+++ b/yescieval/rubric/pairwise/rigor/explicit_uncertainty.py
@@ -77,5 +77,5 @@ Your evaluation must be based solely on the provided research question and respo
 """
 
 class ExplicitUncertainty(PairwiseRubric):
-    name: str = "Explicit Uncertainty"
+    name: str = "ExplicitUncertainty"
     system_prompt_template: str = explicit_uncertainty_pairwise_prompt

--- a/yescieval/rubric/pairwise/rigor/quantitative_evidence.py
+++ b/yescieval/rubric/pairwise/rigor/quantitative_evidence.py
@@ -1,0 +1,84 @@
+from ....base import PairwiseRubric
+
+quantitative_evidence_and_uncertainty_pairwise_prompt = """<Context>
+Scientific question answering and synthesis often require rigorous reasoning using quantitative evidence and appropriate treatment of uncertainty. In synthesis settings (e.g., reports that summarize multiple papers), this is commonly expressed through careful use and interpretation of source-reported quantitative results (e.g., effect sizes, confidence intervals, variability measures), and through explicit reasoning about robustness, heterogeneity, and limitations of the evidence base.
+
+Importantly, not every research question requires (or supports) statistical detail. Some questions are conceptual, mechanistic, methodological, or qualitative. In such cases, it can be rigorous to explicitly state that quantitative estimates are unavailable, incomparable, or not applicable—and to explain why (e.g., heterogeneous outcomes, qualitative designs, sparse or indirect data).
+
+The responses may be short paragraphs or long-form reports. Quantitative evidence handling and uncertainty reasoning should be evaluated independently of presentation style or length.
+
+This rubric focuses exclusively on the presence and quality of quantitative reasoning and uncertainty handling in the two responses being compared,  emphasizing appropriate use, interpretation, and limitation-aware reasoning rather than mere mention of statistical terms or ungrounded numerical claims. Other aspects of scientific quality (such as mechanistic understanding, factual accuracy, evidential grounding, or completeness) are intentionally outside its scope and are assessed by separate evaluation criteria.
+</Context>
+
+<Role>
+You are tasked as a scientific writing quality evaluator performing a pairwise comparison between two texts.
+</Role>
+
+<Task-Description>
+A user will provide:
+1) a research question, and
+2) two written responses (Response A and Response B) intended to address that question.
+
+Your task is to:
+- First, independently evaluate each response using the evaluation characteristic below.
+- Then perform a pairwise comparison of the two responses using the evaluation characteristic below.
+- Then grade each response with a comparative rating from 1 (very bad) to 5 (very good) compared to the other response and a subsequent rationale for each comparative response rating.
+- Note that it is possible for both responses to receive the same rating, if they are equally comparably clear with consistent quantitative reasoning and uncertainty handling and provide complementary or identical insights.
+
+Your judgment must be based solely on the provided question and comparing the two responses w.r.t. addressing the question and w.r.t. each other.
+</Task-Description>
+
+<Evaluation-Characteristic>
+QuantitativeEvidenceAndUncertainty: Does the response appropriately use and interpret quantitative evidence and uncertainty (e.g., effect sizes, confidence intervals, variability, robustness, heterogeneity) in a way that is relevant to the research question? If such quantitative treatment is not needed or not supported by the evidence base, does the response explicitly and reasonably justify why?
+</Evaluation-Characteristic>
+
+<Domain-Vocabulary-Examples>
+Below are domain-specific terms and phrases that often signal quantitative evidence handling and uncertainty reasoning. These are examples only: their presence is not required, and their presence alone is not sufficient for a high score.
+{QUANT_UNCERTAINTY_VOCAB}
+</Domain-Vocabulary-Examples>
+
+<Rating-Scale>
+For the characteristic above, rate the quality from 1 (very bad) to 5 (very good). Follow the guidelines specified below.
+
+QuantitativeEvidenceAndUncertainty
+Rating 1. Very bad: The response is purely descriptive, reporting claims or outcomes with no meaningful quantitative evidence use or uncertainty reasoning, even when the question clearly calls for it; or it makes unqualified quantitative-sounding claims without interpretation.
+Rating 2. Bad: The response contains occasional quantitative/statistical terms or numbers, but interpretation is superficial, generic, misapplied, or weakly connected to the research question; uncertainty/robustness is largely ignored when relevant.
+Rating 3. Moderate: The response demonstrates some relevant quantitative reasoning and/or acknowledges uncertainty, but key interpretations, caveats (e.g., variability, assumptions, comparability), or cross-study considerations (e.g., heterogeneity) are missing, unclear, or inconsistently applied. If quantitative treatment is not needed, the response may gesture at this but without a clear justification.
+Rating 4. Good: The response uses and interprets quantitative evidence appropriately where relevant and connects it to the research question; it discusses uncertainty/robustness with reasonable clarity (e.g., variability, confidence, limitations, heterogeneity) and avoids overclaiming. If quantitative treatment is not needed or not supported, it states this clearly and provides a reasonable explanation.
+Rating 5. Very good: The response demonstrates strong quantitative rigor and uncertainty awareness tightly aligned with the research question, correctly interpreting multiple relevant quantitative indicators (e.g., effect magnitude and uncertainty), explicitly addressing key assumptions/limitations and cross-study heterogeneity/robustness where applicable, and clearly distinguishing what is supported by quantitative evidence from what is not. If quantitative treatment is not needed or not supported, it provides a precise, well-reasoned justification and adjusts conclusions accordingly.
+</Rating-Scale>
+
+<Response-Format>
+Return your evaluation strictly in JSON format:
+
+{
+  "QuantitativeEvidenceAndUncertainty": {
+    "ResponseA": {
+      "rating": "",
+      "rationale": ""
+    },
+    "ResponseB": {
+      "rating": "",
+      "rationale": ""
+    }
+  }
+}
+
+where:
+- "rating" is a number from 1 to 5.
+- "rationale" is the comparative evaluation rating justification.
+
+</Response-Format>
+
+<Example-Responses>
+{EXAMPLE_RESPONSES}
+</Example-Responses>
+
+<Note>
+Your evaluation must be based solely on the provided research question and responses. Do not reward verbosity or statistical jargon by itself; reward relevant quantitative interpretation, uncertainty/robustness awareness, appropriate caveats, and clarity in connecting quantitative evidence to conclusions. This rubric does not assess mechanistic understanding, factual correctness, evidential grounding, or completeness.
+</Note>
+"""
+
+class QuantitativeEvidenceAndUncertainty(PairwiseRubric):
+    name: str = "QuantitativeEvidenceAndUncertainty"
+    system_prompt_template: str = quantitative_evidence_and_uncertainty_pairwise_prompt

--- a/yescieval/rubric/pointwise/rigor/explicit_uncertainty.py
+++ b/yescieval/rubric/pointwise/rigor/explicit_uncertainty.py
@@ -57,5 +57,5 @@ Your evaluation must be based solely on the provided research question and respo
 </Note>"""
 
 class ExplicitUncertainty(PointwiseRubric):
-    name: str = "Explicit Uncertainty"
+    name: str = "ExplicitUncertainty"
     system_prompt_template: str = explicit_uncertainty_prompt


### PR DESCRIPTION
Relevant Issue: #33 
Relevant PRs: #41 

Changes:
* Prompts – Integrated pairwise prompt templates for the deep research dimension: Rigor that includes the rubric EpistemicCalibration, QuantitativeEvidenceAndUncertainty, and ExplicitUncertainty.
* Introduced NLP & Ecology-specific pairwise examples for each rubric.
* Documentation – Added the pairwise evaluation information for the dimension - Rigor.
* Unit test for injectors